### PR TITLE
New events user_created and user_updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ $CFG->event2sns_topicarn = 'arn:aws:sns:us-central-1:9999999999999:my_cool_topic
 // This is a custom site id which will be used by the application / service will receive 
 // the message, in order to identify the source (from where that message came)
 $CFG->event2sns_siteid = 'my_custom_site_id';
+
+// to filter which users creation/update should be tracked. If value is * then all users are tracked, otherwise only the specified end of string
+$CFG->filter_even_user_suffix = 'your-custom-domain.org';
 ``` 
 
 ## Current Supported Events
@@ -24,6 +27,11 @@ sns messages
 * \core\event\course_module_updated
 * \core\event\grade_item_updated 
 * \core\event\course_deleted
+* \core\event\course_restored
+* \core\event\user_graded
+* \core\event\user_created
+* \core\event\user_updated
+
 
 ## Requirements
 *  Moodle 3.1 or greater

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $CFG->event2sns_topicarn = 'arn:aws:sns:us-central-1:9999999999999:my_cool_topic
 $CFG->event2sns_siteid = 'my_custom_site_id';
 
 // to filter which users creation/update should be tracked. If value is * then all users are tracked, otherwise only the specified end of string
-$CFG->filter_even_user_suffix = 'your-custom-domain.org';
+$CFG->filter_event_user_suffix = 'your-custom-domain.org';
 ``` 
 
 ## Current Supported Events

--- a/classes/event_handler.php
+++ b/classes/event_handler.php
@@ -33,6 +33,8 @@ use core\event\course_module_updated;
 use core\event\course_restored;
 use core\event\grade_item_updated;
 use core\event\user_graded;
+use core\event\user_created;
+use core\event\user_updated;
 use mod_assign\event\assessable_submitted;
 use mod_assign\event\submission_graded;
 use dml_exception;
@@ -469,4 +471,85 @@ class event_handler
 
         publish_sns_message($event->get_context(), 'lms_assignments', $data);
     }
+
+
+    /**
+     * Triggers when user is created
+     *
+     * @param user_created $event
+     * @throws dml_exception|coding_exception
+     */
+    public static function user_created(user_created $event)
+    {
+        global $DB;
+        global $CFG;
+
+        if (empty($CFG->filter_event_user_suffix)) {
+            return;
+        }
+
+
+        $event_data = $event->get_data();
+        $record = $DB->get_record($event_data['objecttable'], ['id' => $event_data['objectid']], '*');
+
+        if (!$record) {
+            return;
+        }
+
+        if($CFG->filter_event_user_suffix != '*') {
+            if (!str_ends_with($record->email, $CFG->filter_event_user_suffix)) {
+                return;
+            }
+        }
+
+        $data = [
+            'action' => 'user_created',
+            'user_id' => $record->id,
+            'email' => $record->email,
+            'username' => $record->username,
+        ];
+
+        publish_sns_message($event->get_context(), 'lms_assignments', $data);
+    }
+
+    /**
+     * Triggers when user is updated
+     *
+     * @param user_updated $event
+     * @throws dml_exception|coding_exception
+     */
+    public static function user_updated(user_updated $event)
+    {
+        global $DB;
+        global $CFG;
+
+        if (empty($CFG->filter_event_user_suffix)) {
+            return;
+        }
+
+        $event_data = $event->get_data();
+        $record = $DB->get_record($event_data['objecttable'], ['id' => $event_data['objectid']], '*');
+
+        if (!$record) {
+            return;
+        }
+
+        if($CFG->filter_event_user_suffix != '*') {
+            if (!str_ends_with($record->email, $CFG->filter_event_user_suffix)) {
+                return;
+            }
+        }
+
+        $data = [
+            'action' => 'user_updated',
+            'user_id' => $record->id,
+            'email' => $record->email,
+            'username' => $record->username,
+            'suspended' => $record->suspended,
+        ];
+
+        publish_sns_message($event->get_context(), 'lms_assignments', $data);
+    }
+
+    
 }

--- a/classes/event_handler.php
+++ b/classes/event_handler.php
@@ -55,7 +55,7 @@ class event_handler
      * Capture only those type of modules
      * @var string[]
      */
-    private static $assignment_modules = ['assign', 'quiz'];
+    private static $assignment_modules = ['assign', 'quiz', 'h5pactivity'];
 
     /**
      * Triggers when user submit a assignment

--- a/db/events.php
+++ b/db/events.php
@@ -113,5 +113,13 @@ $observers = [
     [
         'eventname' => '\core\event\course_deleted',
         'callback' => '\local_event2sns\event_handler::course_deleted',
+    ],
+        [
+        'eventname' => '\core\event\user_created',
+        'callback' => '\local_event2sns\event_handler::user_created',
+    ],
+    [
+        'eventname' => '\core\event\user_updated',
+        'callback' => '\local_event2sns\event_handler::user_updated',
     ]
 ];

--- a/db/events.php
+++ b/db/events.php
@@ -114,7 +114,7 @@ $observers = [
         'eventname' => '\core\event\course_deleted',
         'callback' => '\local_event2sns\event_handler::course_deleted',
     ],
-        [
+    [
         'eventname' => '\core\event\user_created',
         'callback' => '\local_event2sns\event_handler::user_created',
     ],

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025090110;            // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version = 2025090200;            // The current plugin version (Date: YYYYMMDDXX)
 $plugin->release = '0.1';
 $plugin->requires = 2018051700;            // Requires this Moodle version.
 $plugin->component = 'local_event2sns';        // Full name of the plugin (used for diagnostics).

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025090200;            // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version = 2025091100;            // The current plugin version (Date: YYYYMMDDXX)
 $plugin->release = '0.1';
 $plugin->requires = 2018051700;            // Requires this Moodle version.
 $plugin->component = 'local_event2sns';        // Full name of the plugin (used for diagnostics).

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025080700;            // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version = 2025090110;            // The current plugin version (Date: YYYYMMDDXX)
 $plugin->release = '0.1';
 $plugin->requires = 2018051700;            // Requires this Moodle version.
 $plugin->component = 'local_event2sns';        // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Added new events:

1. user_created
2. user_updated

**Requirements:**

`$CFG->filter_event_user`

1. When not specified, event will be ignored
2. When value is set to `*` then all users will be processed
3. When specific suffix of email is set, only users with specific email suffix will be processed

Added also the h5pactivity to assignment modules capturing

